### PR TITLE
Add hostname directive

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ services:
   umbrel:
     image: dockurr/umbrel
     container_name: umbrel
+    hostname: umbrel
     ports:
       - 80:80
     volumes:
@@ -38,7 +39,7 @@ services:
 Via Docker CLI:
 
 ```bash
-docker run -it --rm -p 80:80 -v /home/example:/data -v /var/run/docker.sock:/var/run/docker.sock --stop-timeout 60 dockurr/umbrel
+docker run -it --rm -p 80:80 -h umbrel -v /home/example:/data -v /var/run/docker.sock:/var/run/docker.sock --stop-timeout 60 dockurr/umbrel
 ```
 
 ## Stars 🌟


### PR DESCRIPTION
If you use the "-h" directive, you can force a given hostname to the running Docker container. Some host Docker containers (like Nextcloud) create a domain white-list to validate connection origin.

If you need to add your hostname to the Docker configuration (Nextcloud: config.php), you can do that manually. Or, you can add the same hostname into its hosts file or DNS provider.